### PR TITLE
fix(github): Switch from API to HTML scraping to avoid rate limits

### DIFF
--- a/src/recipes/github.ts
+++ b/src/recipes/github.ts
@@ -31,19 +31,8 @@ export const githubRecipe = defineRecipe({
 
 	match: /^https?:\/\/(www\.)?github\.com\/[^/]+\/[^/]+\/?$/i,
 
-	// Use GitHub's public API for reliable data
-	transformUrl: (url: string) => {
-		const match = url.match(/github\.com\/([^/]+)\/([^/]+)/)
-		if (match) {
-			return `https://api.github.com/repos/${match[1]}/${match[2]}`
-		}
-		return url
-	},
-
-	headers: {
-		'Accept': 'application/vnd.github.v3+json',
-		'User-Agent': 'alert.new',
-	},
+	// GitHub blocks simple fetches, use browser rendering
+	requiresJs: true,
 
 	fields: {
 		title: {


### PR DESCRIPTION
Fixes #4

## Problem
GitHub API recipe was failing with 403 errors due to API rate limiting on unauthenticated requests.

## Solution
Switched from using GitHub's API (`transformUrl` to api.github.com) to scraping the actual GitHub repository page using headless browser rendering (`requiresJs: true`). This:
- Avoids API rate limits entirely
- Still extracts all necessary data via HTML parsing patterns already present in the `extract()` function
- Works reliably without authentication

## Changes
- Removed `transformUrl` function that converted URLs to API endpoints
- Removed API-specific headers
- Added `requiresJs: true` to enable browser rendering
- Kept all HTML parsing logic in `extract()` function as fallback

## Testing
Tested with https://github.com/facebook/react - successfully extracts stars, forks, description, and other repository data.