### PR TITLE
Fix YouTube recipe bot detection by enabling JavaScript rendering

### DIFF
--- a/src/recipes/youtube.ts
+++ b/src/recipes/youtube.ts
@@ -32,6 +32,8 @@ export const youtubeRecipe = defineRecipe({
 
 	match: /^https?:\/\/(www\.)?(youtube\.com|youtu\.be)\//i,
 
+	requiresJs: true,
+
 	fields: {
 		title: {
 			type: 'string',


### PR DESCRIPTION
Fixes #27

## Problem
YouTube recipe was failing with bot detection errors because it was using simple fetch() which returns a minimal HTML shell without the embedded JSON data needed for extraction.

## Solution
Added `requiresJs: true` to enable Cloudflare Browser Rendering (headless Chrome). This allows JavaScript to execute and populate the page with ytInitialPlayerResponse and ytInitialData, which the extract() function relies on.

## Testing
Tested with:
- https://www.youtube.com/@mkbhd
- https://www.youtube.com/watch?v=dQw4w9WgXcQ

Both now successfully extract video/channel data including views, likes, subscribers, etc.