### PR TITLE
fix(github): Remove requiresJs to avoid API rate limits

### DIFF
--- a/src/recipes/github.ts
+++ b/src/recipes/github.ts
@@ -31,8 +31,8 @@ export const githubRecipe = defineRecipe({
 
 	match: /^https?:\/\/(www\.)?github\.com\/[^/]+\/[^/]+\/?$/i,
 
-	// GitHub blocks simple fetches, use browser rendering
-	requiresJs: true,
+	// GitHub public pages are accessible via simple fetch
+	// requiresJs: true,  // Disabled - causes API rate limit issues
 
 	fields: {
 		title: {


### PR DESCRIPTION
Fixes #29

## Problem
The GitHub recipe was failing with HTTP 403 due to API rate limiting. The recipe had `requiresJs: true` which was causing it to interact with GitHub's API endpoints that have strict rate limits for unauthenticated requests.

## Solution
Removed `requiresJs: true` to use simple HTTP fetch instead of browser rendering. GitHub's public repository HTML pages are fully accessible without JavaScript and contain all the data we need. The recipe's `extract()` function already has comprehensive HTML parsing fallback logic that works perfectly for this use case.

## Testing
- Verified that https://github.com/facebook/react loads successfully with simple fetch
- Confirmed HTML parsing extracts all key fields (stars, forks, description, etc.)
- No authentication required for public repositories

## Benefits
- Avoids API rate limits entirely
- Faster response times (no browser rendering overhead)
- More reliable for public repository monitoring