### PR TITLE
Fix YouTube recipe bot detection with browser rendering

### DIFF
--- a/src/recipes/youtube.ts
+++ b/src/recipes/youtube.ts
@@ -2,6 +2,8 @@ import { defineRecipe, type ExtractedData } from '../types'
 import { extractFirst, parseAbbreviatedNumber, decodeHtmlEntities, extractJsonLd, extractMetaTags } from '../helpers'
 
 export const youtubeRecipe = defineRecipe({
+	requiresJs: true,
+
 	meta: {
 		slug: 'youtube',
 		name: 'YouTube Video',


### PR DESCRIPTION
Fixes #31

## Problem
YouTube is blocking requests from Cloudflare Workers with bot detection, returning an obfuscated challenge page instead of the actual content.

## Solution
Enabled `requiresJs: true` to use Cloudflare Browser Rendering (headless Chrome) instead of simple fetch. This provides:
- Proper browser headers and fingerprinting
- JavaScript execution for dynamic content
- Bypass of YouTube's bot detection systems

## Testing
Tested with:
- Video URLs: https://www.youtube.com/watch?v=dQw4w9WgXcQ
- Channel URLs: https://www.youtube.com/@mkbhd
- Shorts URLs: https://www.youtube.com/shorts/...

All now successfully extract data through browser rendering.