### PR TITLE
Fix YouTube recipe bot detection with browser rendering

### DIFF
--- a/src/recipes/youtube.ts
+++ b/src/recipes/youtube.ts
@@ -32,6 +32,8 @@ export const youtubeRecipe = defineRecipe({
 
 	match: /^https?:\/\/(www\.)?(youtube\.com|youtu\.be)\//i,
 
+	requiresJs: true,
+
 	fields: {
 		title: {
 			type: 'string',


### PR DESCRIPTION
Fixes #33

## Problem
YouTube recipe was failing with bot detection errors. The site was returning a minimal HTML shell instead of full content when accessed via simple HTTP fetch.

## Solution
Added `requiresJs: true` to enable Cloudflare Browser Rendering (headless Chrome). This bypasses YouTube's bot detection and properly renders the JavaScript-heavy page.

## Testing
Tested with:
- https://www.youtube.com/@mkbhd (channel page)
- https://www.youtube.com/watch?v=dQw4w9WgXcQ (video page)

Both now successfully extract data including views, likes, subscribers, and other metrics.

## Technical Details
YouTube uses extensive JavaScript rendering and has anti-bot measures that block direct HTTP requests. Using browser rendering allows the page to load normally as it would for a real user, enabling the extraction logic to parse ytInitialData and ytInitialPlayerResponse objects that contain all the video/channel metrics.